### PR TITLE
fix project not building on system with non-default libcxx

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ include_directories("include")
 
 option(test "Build tests" OFF)
 
-set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "-std=c++1z -Wimplicit-fallthrough")
+set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "-stdlib=libc++ -std=c++1z -Wimplicit-fallthrough")
 
 if(test)
   find_package(GTest REQUIRED)


### PR DESCRIPTION
I dunno what about systems where everything (or at least clang) is
built against libcxx, but when it just installed, for clang to use its
includes, flag -stdlib=libc++ must be provided.

If we do this, we can make use of things like std::variant, which are
yet to appear in standard standard libraries.